### PR TITLE
Fix substitution in dt systems

### DIFF
--- a/src/functions/dt_DS.py
+++ b/src/functions/dt_DS.py
@@ -113,7 +113,7 @@ def dt_DS(b_degree, dim, L_initial, U_initial, L_unsafe, U_unsafe, L_space, U_sp
     # ========================= Sub Difference Equations =========================
 
     # substitute the result of the difference equations
-    y = sp.symbols(f'y0:{dim}')
+    y = [sp.Dummy(f'y{i}') for i in range(len(x))]
     Barrier_f = Barrier.subs([(x[i], y[i]) for i in range(len(x))])
     Barrier_f = Barrier_f.subs([(y[i], f[i]) for i in range(len(y))])
 

--- a/src/functions/dt_DS.py
+++ b/src/functions/dt_DS.py
@@ -113,7 +113,9 @@ def dt_DS(b_degree, dim, L_initial, U_initial, L_unsafe, U_unsafe, L_space, U_sp
     # ========================= Sub Difference Equations =========================
 
     # substitute the result of the difference equations
-    Barrier_f = Barrier.subs([(x[i], f[i]) for i in range(len(x))])
+    y = sp.symbols(f'y0:{dim}')
+    Barrier_f = Barrier.subs([(x[i], y[i]) for i in range(len(x))])
+    Barrier_f = Barrier_f.subs([(y[i], f[i]) for i in range(len(y))])
 
     # ========================= Constraints =========================
     try:

--- a/src/functions/dt_SS.py
+++ b/src/functions/dt_SS.py
@@ -167,7 +167,9 @@ def dt_SS(b_degree, dim, L_initial, U_initial, L_unsafe, U_unsafe, L_space, U_sp
         return {"error": "Gamma, Lambda, or c value definition issues","b_degree":b_degree}
 
     # ========================= Sub Difference Equations =========================
-    BB = Barrier.subs([(x[i], f[i]) for i in range(len(x))])
+    y = sp.symbols(f'y0:{dim}')
+    BB = Barrier.subs([(x[i], y[i]) for i in range(len(x))])
+    BB = BB.subs([(y[i], f[i]) for i in range(len(y))])
     BB = sp.expand(BB)
 
     for i in range(len(varsigma)):

--- a/src/functions/dt_SS.py
+++ b/src/functions/dt_SS.py
@@ -167,7 +167,7 @@ def dt_SS(b_degree, dim, L_initial, U_initial, L_unsafe, U_unsafe, L_space, U_sp
         return {"error": "Gamma, Lambda, or c value definition issues","b_degree":b_degree}
 
     # ========================= Sub Difference Equations =========================
-    y = sp.symbols(f'y0:{dim}')
+    y = [sp.Dummy(f'y{i}') for i in range(len(x))]
     BB = Barrier.subs([(x[i], y[i]) for i in range(len(x))])
     BB = BB.subs([(y[i], f[i]) for i in range(len(y))])
     BB = sp.expand(BB)


### PR DESCRIPTION
## Bug
As I was tinkering with PRoTECT, I came across this bug in the composition of the barrier and dynamics (`B(f(x, w))` for `dt_SS`). The problem is arising from a quirk in how SymPy applies list substitutions - it's so counter-intuitive and yet undocumented that I would consider it a bug in SymPy. The problem is that performing the multiple/list substitution `[(x[0], f[0]), (x[1], f[1]), ...]` is applied sequentially. So, after `x[0]` is replaced by `f[0]`, if `f[0]` contains the symbol `x[1]` then that symbol is replaced by `f[1]`.

## Solution
Add an intermediate dummy symbol `y` to first substitute with `x` and then substitute `y` with `f` to ensure that the `old_expr` and `new_expr` are defined over a disjoint set of symbols. [The dummy symbol ensures no clash with input symbols.](https://docs.sympy.org/latest/modules/core.html#sympy.core.symbol.Dummy)

## Reproducer
```python
...

# Dynamics
f1 = 0.90 * x[0] + 0.10 * x[1] + 0.45 + varsigma[0]
f2 = 0.90 * x[1] - 0.30 + varsigma[1]
f = np.array([f1, f2])

# Params
params = {
    'b_degree': 2,
    'dim': dim,
    'L_initial': L_initial,
    'U_initial': U_initial,
    'L_unsafe': L_unsafe,
    'U_unsafe': U_unsafe,
    'L_space': L_space,
    'U_space': U_space,
    'x': x,
    'varsigma': varsigma,
    'f': f,
    't': t,
    'noise_type': "gaussian",
    'optimize': True,
    'solver': "mosek",
    'lam': 10,
    'sigma': sigma,
    'mean': mean,
}

res = dt_SS(**params)
```

Barrier structure and `f` (from `print`):
```
f[0] = varsigma0 + 0.9*x0 + 0.1*x1 + 0.45
f[1] = varsigma1 + 0.9*x1 - 0.3
B(x) = Barrier_0 + Barrier_1*x1 + Barrier_2*x0 + Barrier_3*x1**2 + Barrier_4*x0*x1 + Barrier_5*x0**2
```

Output before fix:
```
B(f(x, w)) = Barrier_0 + 
             Barrier_1*(varsigma1 + 0.9*x1 - 0.3) + 
             Barrier_2*(varsigma0 + 0.1*varsigma1 + 0.9*x0 + 0.09*x1 + 0.42) + 
             Barrier_3*(varsigma1 + 0.9*x1 - 0.3)**2 + 
             Barrier_4*(varsigma1 + 0.9*x1 - 0.3)*(varsigma0 + 0.1*varsigma1 + 0.9*x0 + 0.09*x1 + 0.42) + 
             Barrier_5*(varsigma0 + 0.1*varsigma1 + 0.9*x0 + 0.09*x1 + 0.42)**2
```

Output after fix:
```
B(f(x, w)) = Barrier_0 + 
             Barrier_1*(varsigma1 + 0.9*x1 - 0.3) + 
             Barrier_2*(varsigma0 + 0.9*x0 + 0.1*x1 + 0.45) + 
             Barrier_3*(varsigma1 + 0.9*x1 - 0.3)**2 + 
             Barrier_4*(varsigma1 + 0.9*x1 - 0.3)*(varsigma0 + 0.9*x0 + 0.1*x1 + 0.45) + 
             Barrier_5*(varsigma0 + 0.9*x0 + 0.1*x1 + 0.45)**2
```

Drilling into the `Barrier_2` term, after the fix, `x0` is clearly substituted by `f[0]`. Before the fix, it's instead replaced by `f[0]` and then `x1` in `f[0]` is replaced by `f[1]`. That is, 
```
varsigma0 + 0.9*x0 + 0.1*( varsigma1 + 0.9*x1 - 0.3) + 0.45 == varsigma0 + 0.1*varsigma1 + 0.9*x0 + 0.09*x1 + 0.42
```