### PR TITLE
Upgrade Jinja2 to 3.1.6 to fix 4 moderate CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Brian2==2.6.0
 colorama==0.4.6
 cvxopt==1.3.2
 Cython==3.0.10
-Jinja2==3.1.3
+Jinja2==3.1.6
 MarkupSafe==2.1.5
 Mosek==10.1.26
 mpmath==1.3.0


### PR DESCRIPTION
CVE-2024-34064, CVE-2024-56326, CVE-2024-56201, CVE-2025-27516 — all sandbox escape / XSS vulnerabilities patched in 3.1.4–3.1.6.